### PR TITLE
Fix category endpoint recursion bug

### DIFF
--- a/plugins/resources/exports_resources.py
+++ b/plugins/resources/exports_resources.py
@@ -19,7 +19,7 @@ def json_export_resource(resource_id: Union[str, int], export_file =""):
 
     print(f"Fetching resource {resource_id} from API...")
     session = resource_utils.FixedResourceEndpoint()
-    resource = session.get(endpoint_id=526).json()
+    resource = session.get(endpoint_id=resource_id).json()
     resource_json = json.dumps(resource, indent=4)
 
     if export_file == "":

--- a/utils/resource_utils.py
+++ b/utils/resource_utils.py
@@ -19,7 +19,8 @@ class FixedResourceEndpoint:
 
 class FixedCategoryEndpoint:
     def __new__(cls, *args, **kwargs):
-        return FixedCategoryEndpoint("items_types")
+        """Return a fixed endpoint for accessing item categories."""
+        return FixedEndpoint("items_types")
 
 class ResourceIDValidator(Validator):
     def __init__(self, ressource_id: Union[str, int]):


### PR DESCRIPTION
## Summary
- fix recursion in `FixedCategoryEndpoint`
- use correct resource id in resource export

## Testing
- `python -m py_compile utils/resource_utils.py plugins/resources/exports_resources.py`

------
https://chatgpt.com/codex/tasks/task_e_68482e00f77c8331ba868c37a48d1422